### PR TITLE
Clean up missed ChannelBuffer reference

### DIFF
--- a/src/main/java/org/graylog/plugins/netflow/v9/NetFlowV9Header.java
+++ b/src/main/java/org/graylog/plugins/netflow/v9/NetFlowV9Header.java
@@ -16,8 +16,10 @@
 package org.graylog.plugins.netflow.v9;
 
 import com.google.auto.value.AutoValue;
-import org.jboss.netty.buffer.ChannelBuffer;
-import org.jboss.netty.buffer.ChannelBuffers;
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.ByteBufUtil;
+import io.netty.buffer.Unpooled;
+import io.netty.util.ReferenceCountUtil;
 
 @AutoValue
 public abstract class NetFlowV9Header {
@@ -45,14 +47,19 @@ public abstract class NetFlowV9Header {
         return new AutoValue_NetFlowV9Header(version, count, sysUptime, unixSecs, sequence, sourceId);
     }
 
-    public ChannelBuffer encode() {
-        final ChannelBuffer buffer = ChannelBuffers.dynamicBuffer(20);
-        buffer.writeShort(version());
-        buffer.writeShort(count());
-        buffer.writeInt(Math.toIntExact(sysUptime()));
-        buffer.writeInt(Math.toIntExact(unixSecs()));
-        buffer.writeInt(Math.toIntExact(sequence()));
-        buffer.writeInt(Math.toIntExact(sourceId()));
-        return buffer;
+    public String prettyHexDump() {
+        final ByteBuf buffer = Unpooled.buffer(20);
+        try {
+            buffer.writeShort(version());
+            buffer.writeShort(count());
+            buffer.writeInt(Math.toIntExact(sysUptime()));
+            buffer.writeInt(Math.toIntExact(unixSecs()));
+            buffer.writeInt(Math.toIntExact(sequence()));
+            buffer.writeInt(Math.toIntExact(sourceId()));
+
+            return ByteBufUtil.prettyHexDump(buffer);
+        } finally {
+            ReferenceCountUtil.release(buffer);
+        }
     }
 }

--- a/src/main/java/org/graylog/plugins/netflow/v9/RawNetFlowV9Packet.java
+++ b/src/main/java/org/graylog/plugins/netflow/v9/RawNetFlowV9Packet.java
@@ -30,7 +30,7 @@ public abstract class RawNetFlowV9Packet {
     @Override
     public String toString() {
         StringBuilder sb = new StringBuilder("\n");
-        sb.append(ByteBufUtil.prettyHexDump(Unpooled.wrappedBuffer(header().encode().toByteBuffer()))).append("\n");
+        sb.append(header().prettyHexDump()).append("\n");
         sb.append("\nTemplates:\n");
         templates().forEach((integer, byteBuf) -> {
             sb.append("\n").append(integer).append(":\n").append(ByteBufUtil.prettyHexDump(Unpooled.wrappedBuffer(byteBuf)));

--- a/src/test/java/org/graylog/plugins/netflow/v9/NetFlowV9HeaderTest.java
+++ b/src/test/java/org/graylog/plugins/netflow/v9/NetFlowV9HeaderTest.java
@@ -1,0 +1,13 @@
+package org.graylog.plugins.netflow.v9;
+
+import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class NetFlowV9HeaderTest {
+    @Test
+    public void prettyHexDump() {
+        final NetFlowV9Header header = NetFlowV9Header.create(5, 23, 42L, 1000L, 1L, 1L);
+        assertThat(header.prettyHexDump()).isNotEmpty();
+    }
+}


### PR DESCRIPTION
The occurrence of `ChannelBuffer` in `NetFlowV9Header` was missed in the original Netty 4 PR (#28).